### PR TITLE
templates/home: add reload instructions for systemd systems

### DIFF
--- a/oniontip/templates/home.html
+++ b/oniontip/templates/home.html
@@ -53,7 +53,7 @@
             <div class="row">
               <pre class="col-md-10 col-md-offset-1">ContactInfo admin@oniontip.com - 1MiJ46CgV5pJzJy3aHvnwCvvpSN45q3Xva</pre>
             </div>
-            <div class="row"><p class="col-md-10 col-md-offset-1">Once you have made the required modification you will need to reload or restart your relay (<code>service tor reload</code>). After a couple of hours you should see it included in the list below.</p></div>
+            <div class="row"><p class="col-md-10 col-md-offset-1">Once you have made the required modification you will need to reload or restart your relay (<code>service tor reload</code> for systems using SysV init, <code>systemctl reload tor</code> on systems with systemd). After a couple of hours you should see it included in the list below.</p></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
systemd is getting more popular (default init system in RHEL7 and Debian 8), add instructions for reloading the Tor daemon using systemctl.
